### PR TITLE
Fixed invisible characters and indent guides

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -10,7 +10,7 @@ atom-text-editor {
     background-color: @syntax-cursor-line;
   }
 
-  .syntax--invisible {
+  .invisible {
     color: @syntax-text-color;
   }
 
@@ -27,11 +27,11 @@ atom-text-editor {
     box-sizing: border-box;
   }
 
-  .syntax--invisible-character {
+  .invisible-character {
     color: @syntax-invisible-character-color;
   }
 
-  .syntax--indent-guide {
+  .indent-guide {
     color: @syntax-indent-guide-color;
   }
 


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/5394551/21883922/87d5f238-d8b1-11e6-92e2-98dae58ffa52.png)

After:
![after](https://cloud.githubusercontent.com/assets/5394551/21883926/8d9585a8-d8b1-11e6-8f70-d938b241a9db.png)

For the reference:
https://github.com/atom/one-dark-syntax/blob/master/styles/editor.less#L12