### PR TITLE
comments change color on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,18 @@ This theme is also a fork of [One Dark Syntax](https://github.com/atom/one-dark-
 There is also a matching [UI theme](https://atom.io/themes/one-dark-ui).
 
 
-Comments change color when you hover over them so they are unobtrusive when un-needed.
+Comments also change color when you hover over them so they are unobtrusive when un-needed.
+
+## Colors
+
+* `#93ddfb` Anakiwa
+* `#f5faff` Alice Blue
+* `#7e7edd` Chetwode Blue
+* `#9aefea` Blizzard Blue
+* `#85b1e0` Cornflower
+* `#4d8acb` Danube
+* `#dda2f6` Perfume
+* `#a571f4` Portage
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This theme is also a fork of [One Dark Syntax](https://github.com/atom/one-dark-
 
 There is also a matching [UI theme](https://atom.io/themes/one-dark-ui).
 
+
+Comments change color when you hover over them so they are unobtrusive when un-needed.
+
 ### Install
 
 Search for `ariake-dark-syntax` in Settings > Install > Themes.

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -11,16 +11,16 @@
 @mono-3: hsl(@syntax-hue, 17%, 45%);
 
 // Colors -----------------------------------
-@hue-1:   hsl(197, 92%, 78%); // <-cyan
-@hue-2:   hsl(211, 97%, 98%); // <-blue
-@hue-3:   hsl(240, 58%, 68%); // <-purple
-@hue-4:   hsl(177, 72%, 77%); // <-green
+@hue-1:   hsl(197, 92%, 78%); // <-cyan #93ddfb
+@hue-2:   hsl(211, 97%, 98%); // <-white #f5faff
+@hue-3:   hsl(240, 58%, 68%); // <-purple #7e7edd
+@hue-4:   hsl(177, 72%, 77%); // <-teal #9aefea
 
-@hue-5:   hsl(211, 60%, 70%); // <-red 1
-@hue-5-2: hsl(211, 55%, 55%); // <-red 2
+@hue-5:   hsl(211, 60%, 70%); // <-blue 1 ##85b1e0
+@hue-5-2: hsl(211, 55%, 55%); // <-blue 2 #4d8acb
 
-@hue-6:   hsl(282, 82%, 80%); // <-orange 1
-@hue-6-2: hsl(264, 86%, 70%); // <-orange 2
+@hue-6:   hsl(282, 82%, 80%); // <-pink 1 #dda2f6
+@hue-6-2: hsl(264, 86%, 70%); // <-pink 2 #a571f4
 
 
 // Base colors -----------------------------------
@@ -29,3 +29,6 @@
 @syntax-gutter: darken(@syntax-fg, 36%);
 @syntax-guide:  fade(@syntax-fg, 15%);
 @syntax-accent: hsl(@syntax-hue, 100%, 66% );
+
+// Misc ----------------------------------
+@comment-hover: rgb(116, 246, 207);

--- a/styles/language.less
+++ b/styles/language.less
@@ -3,6 +3,12 @@
 .syntax--comment {
   color: @mono-3;
   font-style: italic;
+  transition-duration:1.5s;
+
+.syntax--comment:hover{
+  color: @comment-hover;
+  font-style:italic;
+}
 
   .syntax--markup.syntax--link {
     color: @mono-3;


### PR DESCRIPTION
i love this theme and wanted to contribute! I left everything the same, but I made one small tweak - comments change color when you hover over them - i had originally made the tweak for just myself, but then I had the idea of sending a PR to the main repository so that everyone can use it. The color changes to `rgb(116, 246, 207)` over 1.5s transition duration. If there's another color that the comments could be changed to, please tell me and i'll gladly change it. I thought that this color fit in well with the blue style of the theme.

I also took the liberty of naming each of the colors in hex with comments in `colors.less` so that anyone who wants the colors real quick has easy access to them. I would also think of adding the hex values to the readme to make it ever easier, but i'll leave that decision up to y'all :D.

Thanks - eshanmind :p